### PR TITLE
Speed up CI with mamba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/environment-py${{ matrix.python-version }}.yml') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          mamba-version: '*'
+          channel-priority: strict
           activate-environment: test_env_glidertools # Defined in ci/environment*.yml
           auto-update-conda: false
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
This PR implements a small change to the CI github workflow to use [mamba](https://github.com/mamba-org/mamba) instead of conda, and also set the channel-priority to strict. These should reduce the time needed for each CI workflow to set up.

