### PR TITLE
fix:backscatter darkcount

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -21,6 +21,7 @@ What's New
 
     Bug fixes
     ~~~~~~~~~
+    - Dark count corrections for optical sensors(:pull:'110'). By 'Isabelle Giddy <https://github.com/isgiddy>'_.
 
 v2021.xx (unreleased)
 -------------------------

--- a/glidertools/optics.py
+++ b/glidertools/optics.py
@@ -167,7 +167,7 @@ def backscatter_dark_count(bbp, depth, percentile=95):
     return bbp_dark
 
 
-def fluorescence_dark_count(flr, depth,percentile=95):
+def fluorescence_dark_count(flr, depth, percentile=95):
     """
     Calculates an in situ dark count from the fluorescence sensor.
 
@@ -201,7 +201,6 @@ def fluorescence_dark_count(flr, depth,percentile=95):
             "cannot be made and fluorescence data can't be processed."
         )
     dark_pctl = nanpercentile(flr_dark[mask], percentile)
-
     flr_dark -= dark_pctl
     flr_dark[flr_dark < 0] = 0
 

--- a/glidertools/optics.py
+++ b/glidertools/optics.py
@@ -119,6 +119,8 @@ def par_dark_count(par, depth, time, depth_percentile=90):
     par_dark = par_arr - dark
     par_dark[par_dark < 0] = 0
 
+    return par_dark
+
 
 def backscatter_dark_count(bbp, depth, percentile=5):
     """

--- a/glidertools/optics.py
+++ b/glidertools/optics.py
@@ -113,19 +113,19 @@ def par_dark_count(par, depth, time, depth_percentile=90):
     xi = ma.masked_inside(hrs.astype(int), 22, 2)  # find 23:01 hours
     yi = ma.masked_outside(
         depth, *nanpercentile(depth[~isnan(par)], [depth_percentile, 100])
-    ) # pctl of depth
+    )  # pctl of depth
     i = ~(xi.mask | yi.mask)
     dark = nanmedian(par_arr[i])
     par_dark = par_arr - dark
     par_dark[par_dark < 0] = 0
 
 
-def backscatter_dark_count(bbp, depth, percentile=95):
+def backscatter_dark_count(bbp, depth, percentile=5):
     """
     Calculates an in situ dark count from the backscatter sensor.
 
     The in situ dark count for the backscatter sensor is calculated from the
-    selected percentile between 200 and 400m. 
+    user-defined percentile between 200 and 400m.
 
     Parameters
     ----------
@@ -161,12 +161,12 @@ def backscatter_dark_count(bbp, depth, percentile=95):
     return bbp_dark
 
 
-def fluorescence_dark_count(flr, depth, percentile=95):
+def fluorescence_dark_count(flr, depth, percentile=5):
     """
     Calculates an in situ dark count from the fluorescence sensor.
 
     The in situ dark count for the fluorescence sensor is calculated from the
-    selected percentile between 300 and 400m.
+    user-defined percentile between 300 and 400m.
 
     Parameters
     ----------

--- a/glidertools/optics.py
+++ b/glidertools/optics.py
@@ -126,7 +126,7 @@ def par_dark_count(par, dives, depth, time):
     return par_dark
 
 
-def backscatter_dark_count(bbp, depth,percentile=95):
+def backscatter_dark_count(bbp, depth, percentile=95):
     """
     Calculates an in situ dark count from the backscatter sensor.
 
@@ -158,7 +158,6 @@ def backscatter_dark_count(bbp, depth,percentile=95):
             "made and backscatter data can't be processed."
         )
 
-    
     dark_pctl = nanpercentile(bbp_dark[mask], percentile)
     bbp_dark -= dark_pctl
     bbp_dark[bbp_dark < 0] = 0

--- a/glidertools/optics.py
+++ b/glidertools/optics.py
@@ -112,7 +112,7 @@ def par_dark_count(par, depth, time, depth_percentile=90):
     hrs = time.astype("datetime64[h]") - time.astype("datetime64[D]")
     xi = ma.masked_inside(hrs.astype(int), 22, 2)  # find 23:01 hours
     yi = ma.masked_outside(
-        depth, *nanpercentile(depth[~isnan(par)], [depth_percentile, 100])
+        depth, *nanpercentile(depth[~isnan(par_arr)], [depth_percentile, 100])
     )  # pctl of depth
     i = ~(xi.mask | yi.mask)
     dark = nanmedian(par_arr[i])

--- a/glidertools/optics.py
+++ b/glidertools/optics.py
@@ -126,12 +126,12 @@ def par_dark_count(par, dives, depth, time):
     return par_dark
 
 
-def backscatter_dark_count(bbp, depth):
+def backscatter_dark_count(bbp, depth,percentile=95):
     """
     Calculates an in situ dark count from the backscatter sensor.
 
     The in situ dark count for the backscatter sensor is calculated from the
-    95th percentile between 200 and 400m.
+    95th percentile between 200 and 400m. Change this threshold by adjusting percentile = ...
 
     Parameters
     ----------
@@ -157,14 +157,15 @@ def backscatter_dark_count(bbp, depth):
             "and 400 metres.The dark count correction cannot be "
             "made and backscatter data can't be processed."
         )
-    dark_pctl5 = nanpercentile(bbp_dark[mask], 5)
 
-    bbp_dark -= dark_pctl5
+    
+    dark_pctl = nanpercentile(bbp_dark[mask], percentile)
+    bbp_dark -= dark_pctl
     bbp_dark[bbp_dark < 0] = 0
 
     bbp_dark = transfer_nc_attrs(getframe(), bbp, bbp_dark, "_dark")
 
-    return bbp
+    return bbp_dark
 
 
 def fluorescence_dark_count(flr, depth):

--- a/glidertools/optics.py
+++ b/glidertools/optics.py
@@ -167,7 +167,7 @@ def backscatter_dark_count(bbp, depth, percentile=95):
     return bbp_dark
 
 
-def fluorescence_dark_count(flr, depth):
+def fluorescence_dark_count(flr, depth,percentile=95):
     """
     Calculates an in situ dark count from the fluorescence sensor.
 
@@ -200,10 +200,11 @@ def fluorescence_dark_count(flr, depth):
             "300 and 400 metres.\nThe dark count correction "
             "cannot be made and fluorescence data can't be processed."
         )
-    dark_pctl5 = nanpercentile(flr_dark[mask], 5)
+    dark_pctl = nanpercentile(flr_dark[mask], percentile)
 
-    flr_dark -= dark_pctl5
+    flr_dark -= dark_pctl
     flr_dark[flr_dark < 0] = 0
+
     flr_dark = transfer_nc_attrs(getframe(), flr, flr_dark, "_dark")
 
     return flr_dark

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -42,6 +42,7 @@ def test_sunrise_sunset():
     assert pd.to_datetime(sunset[2]).hour == 12
     assert pd.to_datetime(sunset[2]).minute == 1
 
+
 @pytest.mark.parametrize("percentile", [5, 50, 95])
 def test_backscatter_dark_count(percentile):
     from glidertools.optics import backscatter_dark_count
@@ -161,5 +162,3 @@ def test_par_dark_count_warning():
         UserWarning
     ):  # this line will fail if the command below does not actually raise a warning!
         par_dark_count(par, depth, time, percentile)
-    assert pd.to_datetime(sunset[2]).hour == 12
-    assert pd.to_datetime(sunset[2]).minute == 1

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -39,6 +39,21 @@ def test_sunrise_sunset():
     assert pd.to_datetime(sunrise[2]).hour == 11
     assert pd.to_datetime(sunrise[2]).minute == 59
 
+    import glidertools as gt
+
+    time = [
+        np.datetime64("2000-12-21"),
+        np.datetime64("2000-06-21"),
+    ]
+    lat = (
+        -80,
+        80,
+    )
+    lon = (
+        0,
+        0,
+    )
+
 @pytest.mark.parametrize("percentile", [5, 50, 95])
 def test_backscatter_dark_count(percentile):
     from glidertools.optics import backscatter_dark_count

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -113,6 +113,7 @@ def test_flr_dark_count_negative(percentile):
     assert np.all(flr_dark >= 0)
 
 
+@pytest.mark.parametrize("percentile", [90])
 def test_par_dark_count(percentile):
     #   from glidertools.optics import par_dark_count
     from pandas import date_range

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -87,6 +87,7 @@ def test_backscatter_dark_count_negative(percentile):
 
 def test_backscatter_dark_count_warning():
     from glidertools.optics import backscatter_dark_count
+    import warnings
 
     # create some synthetic data
     percentile = 50
@@ -157,3 +158,20 @@ def test_par_dark_count(percentile):
     )  # only use values in the 90% percentile of depths and between 23:00 and 01:00
     par_dark = par_dark_count(par, depth, time, percentile)
     np.testing.assert_allclose(expected_par_dark, par_dark)
+
+
+def test_par_dark_count_warning():
+    from glidertools.optics import par_dark_count
+    from pandas import date_range
+    import warnings
+
+    # create some synthetic data
+    percentile = 90
+    par = np.array([34, 23.0, 0.89, 0.89])
+    depth = np.array([10, 20, 310, 350])
+    time = date_range("2018-12-01 10:00", "2018-12-03 20:00", 4)
+    # this will trigger the warning  (no values between 200 and 400m)
+    with pytest.warns(
+        UserWarning
+    ):  # this line will fail if the command below does not actually raise a warning!
+        par_dark_count(par, depth, time, percentile)

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -115,7 +115,7 @@ def test_flr_dark_count_negative(percentile):
 
 @pytest.mark.parametrize("percentile", [90])
 def test_par_dark_count(percentile):
-    #   from glidertools.optics import par_dark_count
+    from glidertools.optics import par_dark_count
     from pandas import date_range
 
     # create some synthetic data

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -1,9 +1,6 @@
 import numpy as np
 import pytest
 
-import glidertools as gt
-
-
 def test_sunrise_sunset():
     """
     Tests if sunrise/sunset:
@@ -58,8 +55,9 @@ def test_sunrise_sunset_fail():
         sunrise, sunset = gt.optics.sunset_sunrise(time, lat, lon)
 
 
-@pytest.mark.parametrize("percentile", [95, 85, 50])
+@pytest.mark.parametrize("percentile", [5, 50, 95])
 def test_backscatter_dark_count(percentile):
+    from glidertools.optics import backscatter_dark_count
     # create some synthetic data
     bbp = np.array([0.002, 0.0006, 0.0005, 0.0005, 0.0005])
     depth = np.array([50, 150, 210, 310, 350])
@@ -67,26 +65,26 @@ def test_backscatter_dark_count(percentile):
     mask = (depth > 200) & (depth < 400)
     # expected output
     expected_bbp_dark = bbp - np.nanpercentile(bbp[mask], percentile)
-    bbp_dark = gt.optics.backscatter_dark_count(bbp, depth, percentile)
+    bbp_dark = backscatter_dark_count(bbp, depth, percentile)
     np.testing.assert_allclose(expected_bbp_dark, bbp_dark)
 
 
-@pytest.mark.parametrize("percentile", [95, 75, 50])
+@pytest.mark.parametrize("percentile", [5, 50, 95])
 def test_backscatter_dark_count_negative(percentile):
+    from glidertools.optics import backscatter_dark_count
     # create some synthetic data
     bbp = np.array(
         [0.002, 0.0006, 0.005, 0.005, 0.0004]
     )  # this will result in negative values that should be zeroed out
     depth = np.array([50, 150, 210, 310, 350])
-    mask = (depth > 200) & (depth < 400)
-
-    bbp_dark = gt.optics.backscatter_dark_count(bbp, depth, percentile)
+    bbp_dark = backscatter_dark_count(bbp, depth, percentile)
     # in this case we just want to check if none of the values is negative!
     assert np.all(bbp_dark >= 0)
 
 
-@pytest.mark.parametrize("percentile", [95, 75, 50])
+@pytest.mark.parametrize("percentile", [5, 50,95])
 def test_flr_dark_count(percentile):
+    from glidertools.optics import fluorescence_dark_count
     # create some synthetic data
     flr = np.array([200.0, 100.0, 52.0, 52.0])
     depth = np.array([20, 50, 310, 350])
@@ -94,19 +92,31 @@ def test_flr_dark_count(percentile):
     mask = (depth > 300) & (depth < 400)
     # expected output
     expected_flr_dark = flr - np.nanpercentile(flr[mask], percentile)
-    flr_dark = gt.optics.fluorescence_dark_count(flr, depth, percentile)
+    flr_dark = fluorescence_dark_count(flr, depth, percentile)
     np.testing.assert_allclose(expected_flr_dark, flr_dark)
 
 
-@pytest.mark.parametrize("percentile", [95, 75, 50])
+@pytest.mark.parametrize("percentile", [5, 50, 95])
 def test_flr_dark_count_negative(percentile):
+    from glidertools.optics import fluorescence_dark_count
     # create some synthetic data
     flr = np.array(
         [200.0, 100.0, 152.0, 151.0]
     )  # this will result in negative values that should be zeroed out
     depth = np.array([20, 50, 310, 350])
-    mask = (depth > 300) & (depth < 400)
-    expected_flr_dark = flr - np.nanpercentile(flr[mask], percentile)
-    flr_dark = gt.optics.fluorescence_dark_count(flr, depth, percentile)
+    flr_dark = fluorescence_dark_count(flr], depth, percentile)
     # in this case we just want to check if none of the values is negative!
     assert np.all(flr_dark >= 0)
+
+
+def test_par_dark_count(percentile):
+#     from glidertools.optics import par_dark_count
+    from pandas import date_range
+    # create some synthetic data
+    par = np.array([34,23.,0.89,0.89]) 
+    depth = np.array([10,20,310,350])    
+    time = date_range('2018-12-01 10:00','2018-12-03 00:00',4) 
+    #expected output
+    expected_par_dark = par - np.nanmedian(np.nanpercentile(par[-1], percentile) )  # only use values in the 90% percentile of depths and between 23:00 and 01:00
+    par_dark = par_dark_count(par, depth, time, percentile)
+    np.testing.assert_allclose(expected_par_dark, par_dark)

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -55,7 +55,7 @@ def test_sunrise_sunset_fail():
         sunrise, sunset = gt.optics.sunset_sunrise(time, lat, lon)
 
 
-@pytest.mark.parametrize('percentile', [95, 85, 50])
+@pytest.mark.parametrize("percentile", [95, 85, 50])
 def test_backscatter_dark_count(percentile):
     # create some synthetic data
     bbp = np.array([0.002, 0.0006, 0.0005, 0.0005, 0.0005])
@@ -68,7 +68,7 @@ def test_backscatter_dark_count(percentile):
     np.testing.assert_allclose(expected_bbp_dark, bbp_dark)
 
 
-@pytest.mark.parametrize('percentile', [95, 75, 50])
+@pytest.mark.parametrize("percentile", [95, 75, 50])
 def test_backscatter_dark_count_negative(percentile):
     # create some synthetic data
     bbp = np.array(
@@ -82,7 +82,7 @@ def test_backscatter_dark_count_negative(percentile):
     assert np.all(bbp_dark >= 0)
 
 
-@pytest.mark.parametrize('percentile', [95, 75, 50])
+@pytest.mark.parametrize("percentile", [95, 75, 50])
 def test_flr_dark_count(percentile):
     # create some synthetic data
     flr = np.array([200.0, 100.0, 52.0, 52.0])
@@ -95,7 +95,7 @@ def test_flr_dark_count(percentile):
     np.testing.assert_allclose(expected_flr_dark, flr_dark)
 
 
-@pytest.mark.parametrize('percentile', [95, 75, 50])
+@pytest.mark.parametrize("percentile", [95, 75, 50])
 def test_flr_dark_count_negative(percentile):
     # create some synthetic data
     flr = np.array(

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -53,3 +53,26 @@ def test_sunrise_sunset_fail():
 
     with pytest.raises(ValueError):
         sunrise, sunset = gt.optics.sunset_sunrise(time, lat, lon)
+
+@pytest.mark.parametrize(percentile, [95, 85, 50]) 
+def test_backscatter_dark_count(percentile):
+    # create some synthetic data
+    bbp = np.array([0.002,0.0006,0.0005,0.0005, 0.0005]) 
+    depth = np.array([50,150,210,310,350])     
+    #select only depths between 200 and 400
+    mask = (depth > 200) & (depth < 400)  
+    #expected output
+    expected_bbp_dark = bbp - np.nanpercentile(bbp[mask], percentile) 
+    bbp_dark = gt.optics.backscatter_dark_count(bbp, depth, percentile)
+    np.testing.assert_allclose(expected_bbp_dark, bbp_dark)
+
+@pytest.mark.parametrize(percentile, [95, 75, 50]) 
+def test_backscatter_dark_count_negative(percentile):
+    # create some synthetic data
+    bbp = np.array([0.002,0.0006,0.005,0.005, 0.0004])  # this will result in negative values that should be zeroed out
+    depth = np.array([50,150,210,310,350]) 
+    mask = (depth > 200) & (depth < 400)
+
+    bbp_dark = gt.optics.backscatter_dark_count(bbp, depth, percentile)
+    # in this case we just want to check if none of the values is negative!
+    assert np.all(bbp_dark >=0)

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -1,4 +1,7 @@
 import pytest
+import numpy as np
+import glidertools as gt
+
 
 
 def test_sunrise_sunset():

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -39,26 +39,6 @@ def test_sunrise_sunset():
     assert pd.to_datetime(sunrise[2]).hour == 11
     assert pd.to_datetime(sunrise[2]).minute == 59
 
-<<<<<<< HEAD
-    import glidertools as gt
-
-    time = [
-        np.datetime64("2000-12-21"),
-        np.datetime64("2000-06-21"),
-    ]
-    lat = (
-        -80,
-        80,
-    )
-    lon = (
-        0,
-        0,
-    )
-
-    with pytest.raises(ValueError):
-        sunrise, sunset = gt.optics.sunset_sunrise(time, lat, lon)
-
-
 @pytest.mark.parametrize("percentile", [5, 50, 95])
 def test_backscatter_dark_count(percentile):
     from glidertools.optics import backscatter_dark_count
@@ -178,7 +158,5 @@ def test_par_dark_count_warning():
         UserWarning
     ):  # this line will fail if the command below does not actually raise a warning!
         par_dark_count(par, depth, time, percentile)
-=======
     assert pd.to_datetime(sunset[2]).hour == 12
     assert pd.to_datetime(sunset[2]).minute == 1
->>>>>>> 5db12d687b3b74152c4c351b58826336c0455021

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -54,6 +54,7 @@ def test_sunrise_sunset():
         0,
     )
 
+
 @pytest.mark.parametrize("percentile", [5, 50, 95])
 def test_backscatter_dark_count(percentile):
     from glidertools.optics import backscatter_dark_count

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -55,7 +55,7 @@ def test_sunrise_sunset_fail():
         sunrise, sunset = gt.optics.sunset_sunrise(time, lat, lon)
 
 
-@pytest.mark.parametrize(percentile, [95, 85, 50])
+@pytest.mark.parametrize('percentile', [95, 85, 50])
 def test_backscatter_dark_count(percentile):
     # create some synthetic data
     bbp = np.array([0.002, 0.0006, 0.0005, 0.0005, 0.0005])
@@ -68,7 +68,7 @@ def test_backscatter_dark_count(percentile):
     np.testing.assert_allclose(expected_bbp_dark, bbp_dark)
 
 
-@pytest.mark.parametrize(percentile, [95, 75, 50])
+@pytest.mark.parametrize('percentile', [95, 75, 50])
 def test_backscatter_dark_count_negative(percentile):
     # create some synthetic data
     bbp = np.array(
@@ -82,7 +82,7 @@ def test_backscatter_dark_count_negative(percentile):
     assert np.all(bbp_dark >= 0)
 
 
-@pytest.mark.parametrize(percentile, [95, 75, 50])
+@pytest.mark.parametrize('percentile', [95, 75, 50])
 def test_flr_dark_count(percentile):
     # create some synthetic data
     flr = np.array([200.0, 100.0, 52.0, 52.0])
@@ -95,7 +95,7 @@ def test_flr_dark_count(percentile):
     np.testing.assert_allclose(expected_flr_dark, flr_dark)
 
 
-@pytest.mark.parametrize(percentile, [95, 75, 50])
+@pytest.mark.parametrize('percentile', [95, 75, 50])
 def test_flr_dark_count_negative(percentile):
     # create some synthetic data
     flr = np.array(

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+
 def test_sunrise_sunset():
     """
     Tests if sunrise/sunset:
@@ -58,6 +59,7 @@ def test_sunrise_sunset_fail():
 @pytest.mark.parametrize("percentile", [5, 50, 95])
 def test_backscatter_dark_count(percentile):
     from glidertools.optics import backscatter_dark_count
+
     # create some synthetic data
     bbp = np.array([0.002, 0.0006, 0.0005, 0.0005, 0.0005])
     depth = np.array([50, 150, 210, 310, 350])
@@ -72,6 +74,7 @@ def test_backscatter_dark_count(percentile):
 @pytest.mark.parametrize("percentile", [5, 50, 95])
 def test_backscatter_dark_count_negative(percentile):
     from glidertools.optics import backscatter_dark_count
+
     # create some synthetic data
     bbp = np.array(
         [0.002, 0.0006, 0.005, 0.005, 0.0004]
@@ -82,9 +85,10 @@ def test_backscatter_dark_count_negative(percentile):
     assert np.all(bbp_dark >= 0)
 
 
-@pytest.mark.parametrize("percentile", [5, 50,95])
+@pytest.mark.parametrize("percentile", [5, 50, 95])
 def test_flr_dark_count(percentile):
     from glidertools.optics import fluorescence_dark_count
+
     # create some synthetic data
     flr = np.array([200.0, 100.0, 52.0, 52.0])
     depth = np.array([20, 50, 310, 350])
@@ -99,24 +103,27 @@ def test_flr_dark_count(percentile):
 @pytest.mark.parametrize("percentile", [5, 50, 95])
 def test_flr_dark_count_negative(percentile):
     from glidertools.optics import fluorescence_dark_count
+
     # create some synthetic data
-    flr = np.array(
-        [200.0, 100.0, 152.0, 151.0]
-    )  # this will result in negative values that should be zeroed out
+    flr = np.array([200.0, 100.0, 152.0, 151.0])
+    # this will result in negative values that should be zeroed out
     depth = np.array([20, 50, 310, 350])
-    flr_dark = fluorescence_dark_count(flr], depth, percentile)
+    flr_dark = fluorescence_dark_count(flr, depth, percentile)
     # in this case we just want to check if none of the values is negative!
     assert np.all(flr_dark >= 0)
 
 
 def test_par_dark_count(percentile):
-#     from glidertools.optics import par_dark_count
+    #   from glidertools.optics import par_dark_count
     from pandas import date_range
+
     # create some synthetic data
-    par = np.array([34,23.,0.89,0.89]) 
-    depth = np.array([10,20,310,350])    
-    time = date_range('2018-12-01 10:00','2018-12-03 00:00',4) 
-    #expected output
-    expected_par_dark = par - np.nanmedian(np.nanpercentile(par[-1], percentile) )  # only use values in the 90% percentile of depths and between 23:00 and 01:00
+    par = np.array([34, 23.0, 0.89, 0.89])
+    depth = np.array([10, 20, 310, 350])
+    time = date_range("2018-12-01 10:00", "2018-12-03 00:00", 4)
+    # expected output
+    expected_par_dark = par - np.nanmedian(
+        np.nanpercentile(par[-1], percentile)
+    )  # only use values in the 90% percentile of depths and between 23:00 and 01:00
     par_dark = par_dark_count(par, depth, time, percentile)
     np.testing.assert_allclose(expected_par_dark, par_dark)

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -1,7 +1,7 @@
-import pytest
 import numpy as np
-import glidertools as gt
+import pytest
 
+import glidertools as gt
 
 
 def test_sunrise_sunset():

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -39,21 +39,8 @@ def test_sunrise_sunset():
     assert pd.to_datetime(sunrise[2]).hour == 11
     assert pd.to_datetime(sunrise[2]).minute == 59
 
-    import glidertools as gt
-
-    time = [
-        np.datetime64("2000-12-21"),
-        np.datetime64("2000-06-21"),
-    ]
-    lat = (
-        -80,
-        80,
-    )
-    lon = (
-        0,
-        0,
-    )
-
+    assert pd.to_datetime(sunset[2]).hour == 12
+    assert pd.to_datetime(sunset[2]).minute == 1
 
 @pytest.mark.parametrize("percentile", [5, 50, 95])
 def test_backscatter_dark_count(percentile):

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -85,6 +85,21 @@ def test_backscatter_dark_count_negative(percentile):
     assert np.all(bbp_dark >= 0)
 
 
+def test_backscatter_dark_count_warning():
+    from glidertools.optics import backscatter_dark_count
+
+    # create some synthetic data
+    percentile = 50
+    bbp = np.array([0.002, 0.0006, 0.005, 0.005])
+    depth = np.array(
+        [50, 60, 70, 110]
+    )  # this will trigger the warning  (no values between 200 and 400m)
+    with pytest.warns(
+        UserWarning
+    ):  # this line will fail if the command below does not actually raise a warning!
+        backscatter_dark_count(bbp, depth, percentile)
+
+
 @pytest.mark.parametrize("percentile", [5, 50, 95])
 def test_flr_dark_count(percentile):
     from glidertools.optics import fluorescence_dark_count
@@ -111,6 +126,20 @@ def test_flr_dark_count_negative(percentile):
     flr_dark = fluorescence_dark_count(flr, depth, percentile)
     # in this case we just want to check if none of the values is negative!
     assert np.all(flr_dark >= 0)
+
+
+def test_flr_dark_count_warning():
+    from glidertools.optics import fluorescence_dark_count
+
+    # create some synthetic data
+    percentile = 50
+    flr = np.array([200.0, 100.0, 52.0, 52.0])
+    depth = np.array([20, 50, 210, 250])
+
+    with pytest.warns(
+        UserWarning
+    ):  # this line will fail if the command below does not actually raise a warning!
+        fluorescence_dark_count(flr, depth, percentile)
 
 
 @pytest.mark.parametrize("percentile", [90])

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -76,3 +76,26 @@ def test_backscatter_dark_count_negative(percentile):
     bbp_dark = gt.optics.backscatter_dark_count(bbp, depth, percentile)
     # in this case we just want to check if none of the values is negative!
     assert np.all(bbp_dark >=0)
+
+@pytest.mark.parametrize(percentile, [95, 75, 50]) 
+def test_flr_dark_count(percentile):
+    # create some synthetic data
+    flr = np.array([200.,100.,52.,52.]) 
+    depth = np.array([20,50,310,350])     
+    #select only depths between 200 and 400
+    mask = (depth > 300) & (depth < 400)  
+    #expected output
+    expected_flr_dark = flr - np.nanpercentile(flr[mask], percentile) 
+    flr_dark = gt.optics.fluorescence_dark_count(flr, depth, percentile)
+    np.testing.assert_allclose(expected_flr_dark, flr_dark)
+
+@pytest.mark.parametrize(percentile, [95, 75, 50]) 
+def test_flr_dark_count_negative(percentile):
+    # create some synthetic data
+    flr = np.array([200.,100.,152.,151.])  # this will result in negative values that should be zeroed out
+    depth = np.array([20,50,310,350])
+    mask = (depth > 300) & (depth < 400)
+    expected_flr_dark = flr - np.nanpercentile(flr[mask], percentile) 
+    flr_dark = gt.optics.fluorescence_dark_count(flr, depth, percentile)
+    # in this case we just want to check if none of the values is negative!
+    assert np.all(flr_dark >=0)

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -54,48 +54,56 @@ def test_sunrise_sunset_fail():
     with pytest.raises(ValueError):
         sunrise, sunset = gt.optics.sunset_sunrise(time, lat, lon)
 
-@pytest.mark.parametrize(percentile, [95, 85, 50]) 
+
+@pytest.mark.parametrize(percentile, [95, 85, 50])
 def test_backscatter_dark_count(percentile):
     # create some synthetic data
-    bbp = np.array([0.002,0.0006,0.0005,0.0005, 0.0005]) 
-    depth = np.array([50,150,210,310,350])     
-    #select only depths between 200 and 400
-    mask = (depth > 200) & (depth < 400)  
-    #expected output
-    expected_bbp_dark = bbp - np.nanpercentile(bbp[mask], percentile) 
+    bbp = np.array([0.002, 0.0006, 0.0005, 0.0005, 0.0005])
+    depth = np.array([50, 150, 210, 310, 350])
+    # select only depths between 200 and 400
+    mask = (depth > 200) & (depth < 400)
+    # expected output
+    expected_bbp_dark = bbp - np.nanpercentile(bbp[mask], percentile)
     bbp_dark = gt.optics.backscatter_dark_count(bbp, depth, percentile)
     np.testing.assert_allclose(expected_bbp_dark, bbp_dark)
 
-@pytest.mark.parametrize(percentile, [95, 75, 50]) 
+
+@pytest.mark.parametrize(percentile, [95, 75, 50])
 def test_backscatter_dark_count_negative(percentile):
     # create some synthetic data
-    bbp = np.array([0.002,0.0006,0.005,0.005, 0.0004])  # this will result in negative values that should be zeroed out
-    depth = np.array([50,150,210,310,350]) 
+    bbp = np.array(
+        [0.002, 0.0006, 0.005, 0.005, 0.0004]
+    )  # this will result in negative values that should be zeroed out
+    depth = np.array([50, 150, 210, 310, 350])
     mask = (depth > 200) & (depth < 400)
 
     bbp_dark = gt.optics.backscatter_dark_count(bbp, depth, percentile)
     # in this case we just want to check if none of the values is negative!
-    assert np.all(bbp_dark >=0)
+    assert np.all(bbp_dark >= 0)
 
-@pytest.mark.parametrize(percentile, [95, 75, 50]) 
+
+@pytest.mark.parametrize(percentile, [95, 75, 50])
 def test_flr_dark_count(percentile):
     # create some synthetic data
-    flr = np.array([200.,100.,52.,52.]) 
-    depth = np.array([20,50,310,350])     
-    #select only depths between 200 and 400
-    mask = (depth > 300) & (depth < 400)  
-    #expected output
-    expected_flr_dark = flr - np.nanpercentile(flr[mask], percentile) 
+    flr = np.array([200.0, 100.0, 52.0, 52.0])
+    depth = np.array([20, 50, 310, 350])
+    # select only depths between 200 and 400
+    mask = (depth > 300) & (depth < 400)
+    # expected output
+    expected_flr_dark = flr - np.nanpercentile(flr[mask], percentile)
     flr_dark = gt.optics.fluorescence_dark_count(flr, depth, percentile)
     np.testing.assert_allclose(expected_flr_dark, flr_dark)
 
-@pytest.mark.parametrize(percentile, [95, 75, 50]) 
+
+@pytest.mark.parametrize(percentile, [95, 75, 50])
 def test_flr_dark_count_negative(percentile):
     # create some synthetic data
-    flr = np.array([200.,100.,152.,151.])  # this will result in negative values that should be zeroed out
-    depth = np.array([20,50,310,350])
+    flr = np.array(
+        [200.0, 100.0, 152.0, 151.0]
+    )  # this will result in negative values that should be zeroed out
+    depth = np.array([20, 50, 310, 350])
     mask = (depth > 300) & (depth < 400)
-    expected_flr_dark = flr - np.nanpercentile(flr[mask], percentile) 
+    expected_flr_dark = flr - np.nanpercentile(flr[mask], percentile)
     flr_dark = gt.optics.fluorescence_dark_count(flr, depth, percentile)
     # in this case we just want to check if none of the values is negative!
-    assert np.all(flr_dark >=0)
+    assert np.all(flr_dark >= 0)


### PR DESCRIPTION
This is a small fix to the backscatter dark count function.
The percentile was not being correctly computed and the output was returning the input. 

It now functions correctly and I added an option so that users can select their own percentile. 

Should I create a unit test for this too? 

Returns the following warning, which I don't think is an issue? 
.```
./../../../dev/Glidertools/glidertools/helpers.py:71: GliderToolsWarning: Primary input variable is not xr.DataArray data type - no metadata to pass on.
  warnings.warn(msg, category=GliderToolsWarning)
```

I am a bit confused about the checklist below. @jbusecke is this elaborated somewhere in the discussions? 

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Passes `pre-commit run --all-files`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
