### PR TITLE
More verbose check for warnings

### DIFF
--- a/glidertools/plot.py
+++ b/glidertools/plot.py
@@ -135,7 +135,7 @@ class plot_functions(object):
         gridding_dz = kwargs.pop("gridding_dz", 1)
 
         # set default shading and rasterized for pcolormesh (can be overriden by user)
-        # kwargs.setdefault("shading", "nearest")
+        kwargs.setdefault("shading", "nearest")
         kwargs.setdefault("rasterized", "True")
 
         x, y, z, name = _process_2D_plot_args(args, gridding_dz=gridding_dz)

--- a/glidertools/plot.py
+++ b/glidertools/plot.py
@@ -135,7 +135,7 @@ class plot_functions(object):
         gridding_dz = kwargs.pop("gridding_dz", 1)
 
         # set default shading and rasterized for pcolormesh (can be overriden by user)
-        kwargs.setdefault("shading", "nearest")
+        # kwargs.setdefault("shading", "nearest")
         kwargs.setdefault("rasterized", "True")
 
         x, y, z, name = _process_2D_plot_args(args, gridding_dz=gridding_dz)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -16,6 +16,12 @@ dat = ds_dict["sg_data_point"]
 
 def test_no_warns():
     """Check gt_plt() raises no warnings in pcolormesh."""
-    with pytest.warns(None) as record:
+    with pytest.warns(None) as warnings:
+        import warnings
+        warnings.warn(UserWarning, 'Just Testing')
         gt_plt(dat.dives, dat.ctd_pressure, dat.salinity)
-    assert not record
+     
+    if len(record) > 0:
+        raise AssertionError(
+                "Warnings were raised: " + ", ".join([str(w) for w in warnings])
+            )

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -17,9 +17,6 @@ dat = ds_dict["sg_data_point"]
 def test_no_warns():
     """Check gt_plt() raises no warnings in pcolormesh."""
     with pytest.warns(None) as record:
-        import warnings
-
-        warnings.warn("Some random warning")  # this should just be ignored.
         gt_plt(dat.dives, dat.ctd_pressure, dat.salinity)
 
     # print warnings that were captured

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -19,7 +19,7 @@ def test_no_warns():
     with pytest.warns(None) as record:
         import warnings
 
-        warnings.warn("Some random warning")
+        warnings.warn("Some random warning")  # this should just be ignored.
         gt_plt(dat.dives, dat.ctd_pressure, dat.salinity)
 
     # print warnings that were captured

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -18,9 +18,9 @@ def test_no_warns():
     """Check gt_plt() raises no warnings in pcolormesh."""
     with pytest.warns(None) as warnings:
         import warnings
-        warnings.warn(UserWarning, 'Just Testing')
+        warnings.warn('Just Testing', UserWarning)
         gt_plt(dat.dives, dat.ctd_pressure, dat.salinity)
-     
+    
     if len(record) > 0:
         raise AssertionError(
                 "Warnings were raised: " + ", ".join([str(w) for w in warnings])

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -16,12 +16,18 @@ dat = ds_dict["sg_data_point"]
 
 def test_no_warns():
     """Check gt_plt() raises no warnings in pcolormesh."""
-    with pytest.warns(None) as warnings:
+    with pytest.warns(None) as record:
         import warnings
-        warnings.warn('Just Testing', UserWarning)
+
+        warnings.warn("Some random warning")
         gt_plt(dat.dives, dat.ctd_pressure, dat.salinity)
-    
+
+    # print warnings that were captured
     if len(record) > 0:
-        raise AssertionError(
-                "Warnings were raised: " + ", ".join([str(w) for w in warnings])
-            )
+        print("Warnings were raised: " + ", ".join([str(w) for w in record]))
+
+    # Check the warning messages for statements we do not want to see
+    fail_message = (
+        "shading='flat' when X and Y have the same dimensions as C is deprecated"
+    )
+    assert not any([fail_message in str(r) for r in record])


### PR DESCRIPTION
It is hard to diagnose what warning is raised in #121. Here I am trying to modify the test, so that any warning that **is** raised gets displayed.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Passes `pre-commit run --all-files`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
