### PR TITLE
 Committer: Martin Mohrmann <coffee@pop-os.localdomain>

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.1.0
+  rev: v4.3.0
   hooks:
     - id: trailing-whitespace
     - id: check-ast
@@ -10,26 +10,26 @@ repos:
     - id: check-added-large-files
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.9
+  rev: 3.9.2
   hooks:
     - id: flake8
+      args: ["--max-line-length=105", "--select=C,E,F,W,B,B950", "--ignore=E203,E501,W503"]
       exclude: docs/source/conf.py
-      args: [--max-line-length=105, --ignore=E203,E501,W503, --select=select=C,E,F,W,B,B950]
 
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
+  rev: v5.10.1
   hooks:
   - id: isort
     additional_dependencies: [toml]
     args: [--project=glidertools, --multi-line=3, --lines-after-imports=2, --lines-between-types=1, --trailing-comma, --force-grid-wrap=0, --use-parentheses, --line-width=88]
 
 - repo: https://github.com/asottile/seed-isort-config
-  rev: v2.1.1
+  rev: v2.2.0
   hooks:
     - id: seed-isort-config
 
 - repo: https://github.com/psf/black
-  rev: 20.8b1
+  rev: 22.10.0
   hooks:
   - id: black
     language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     - id: check-docstring-first
     - id: check-added-large-files
 
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: 3.9.2
   hooks:
     - id: flake8

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -4,8 +4,8 @@ channels:
 dependencies:
   - numexpr
   - netCDF4
-  - pandas<1.3.0
-  - xarray>v2022.12.0
+  - pandas
+  - xarray >=v2022.10.0
   - numpy
   - scikit-learn
   - scipy

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - numexpr
   - netCDF4
   - pandas
-  - xarray >=v2022.10.0
+  - xarray >=2022.10.0
   - numpy
   - scikit-learn
   - scipy

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - numexpr
   - netCDF4
   - pandas<1.3.0
-  - xarray
+  - xarray>v2022.12.0
   - numpy
   - scikit-learn
   - scipy

--- a/docs/authors.md
+++ b/docs/authors.md
@@ -16,6 +16,7 @@ The following people have made contributions to the project (in alphabetical ord
 - [Julius Busecke](http://jbusecke.github.io/) -  Columbia University, USA. (ORCID: [0000-0001-8571-865X](https://orcid.org/0000-0001-8571-865X))
 - [Isabelle Giddy](https://github.com/isgiddy/) - University of Cape Town: Cape Town, Western Cape, South Africa. (ORCID: [0000-0002-8926-3311](https://orcid.org/0000-0002-8926-3311))
 - [Luke Gregor](https://github.com/lukegre) - Environmental Physics, ETH Zuerich: Zurich, Switzerland. (ORCID: [0000-0001-6071-1857](https://orcid.org/0000-0001-6071-1857))
+- [Martin Mohrmann](https://github.com/MartinMohrmann) - Voice of the Ocean Foundation, Gothenburg, Sweden. (ORCID: [0000-0001-8056-4866](https://orcid.org/0000-0001-8056-4866))
 - [Sarah-Anne Nicholson](https://github.com/sarahnicholson) - Council for Scientific and Industrial Research: Cape Town, South Africa. (ORCID: [0000-0002-1226-1828](https://orcid.org/0000-0002-1226-1828))
 - [Marcel du Plessis](https://mduplessis.com) - University of Cape Town: Cape Town, Western Cape, South Africa. (ORCID: [0000-0003-2759-2467](https://orcid.org/0000-0003-2759-2467))
 - [Callum Rollo](https://callumrollo.github.io/) -  University of East Anglia, UK. (ORCID: [0000-0002-5134-7886](https://orcid.org/0000-0002-5134-7886))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,8 +60,8 @@ napoleon_numpy_docstring = True
 master_doc = "index"
 
 # General information about the project.
-project = u"GliderTools"
-copyright = u"GliderTools, 2019"
+project = "GliderTools"
+copyright = "GliderTools, 2019"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -230,8 +230,8 @@ latex_documents = [
     (
         "index",
         "ReadtheDocsTemplate.tex",
-        u"Read the Docs Template Documentation",
-        u"Read the Docs",
+        "Read the Docs Template Documentation",
+        "Read the Docs",
         "manual",
     ),
 ]
@@ -265,8 +265,8 @@ man_pages = [
     (
         "index",
         "readthedocstemplate",
-        u"Read the Docs Template Documentation",
-        [u"Read the Docs"],
+        "Read the Docs Template Documentation",
+        ["Read the Docs"],
         1,
     )
 ]
@@ -284,8 +284,8 @@ texinfo_documents = [
     (
         "index",
         "ReadtheDocsTemplate",
-        u"Read the Docs Template Documentation",
-        u"Read the Docs",
+        "Read the Docs Template Documentation",
+        "Read the Docs",
         "ReadtheDocsTemplate",
         "Miscellaneous",
     ),

--- a/glidertools/cleaning.py
+++ b/glidertools/cleaning.py
@@ -715,9 +715,9 @@ def savitzky_golay(var, window_size, order, deriv=0, rate=1, interpolate=True):
 
     # precompute coefficients
     b = mat(
-        [[k ** i for i in order_range] for k in range(-half_window, half_window + 1)]
+        [[k**i for i in order_range] for k in range(-half_window, half_window + 1)]
     )
-    m = linalg.pinv(b).A[deriv] * rate ** deriv * factorial(deriv)
+    m = linalg.pinv(b).A[deriv] * rate**deriv * factorial(deriv)
     # pad the signal at the extremes with
     # values taken from the signal itself
     firstvals = y[0] - abs(y[1 : half_window + 1][::-1] - y[0])

--- a/glidertools/helpers.py
+++ b/glidertools/helpers.py
@@ -38,7 +38,7 @@ def rebuild_func_call(frame):
         if len(arg_valu) < 25:
             try:
                 float(arg_valu)
-            except:
+            except ValueError:
                 if (arg_valu == "True") | (arg_valu == "False"):
                     pass
                 else:

--- a/glidertools/load/seaglider.py
+++ b/glidertools/load/seaglider.py
@@ -327,7 +327,7 @@ def read_nc_files_strings(files, keys, verbose=True):
         df[col] = df[col].str.encode("ascii", "ignore").str.decode("ascii")
         try:
             df[col] = df[col].values.astype(float)
-        except:
+        except ValueError:
             pass
     df["dives"] = idx
 
@@ -584,11 +584,11 @@ def make_xr_dataset(
             coords[i] = coord + "_dt64"
 
     xds = (
-        df.reset_index(drop=True)
-        .to_xarray()
-        .drop("index")
-        .rename({"index": index_name})
+        df.to_xarray()
+        .drop_indexes(df.index.name)
+        .reset_coords()
         .set_coords(coords)
+        .rename_dims({df.index.name: index_name})
         .assign_attrs(global_attrs)
     )
 

--- a/glidertools/load/slocum.py
+++ b/glidertools/load/slocum.py
@@ -26,6 +26,7 @@ def slocum_geomar_matfile(filename, verbose=True):
 
     import numpy as np
     import pandas as pd
+
     from scipy.io import loadmat
 
     mat = loadmat(filename)

--- a/glidertools/mapping.py
+++ b/glidertools/mapping.py
@@ -315,7 +315,7 @@ class QuadTree:
 
         #############
         # DIAGONALS #
-        xs, ys = (root.sizes / 2 ** root.max_depth) / 2
+        xs, ys = (root.sizes / 2**root.max_depth) / 2
         neighbours += [
             root.query_xy(self.xlim[0] - xs, self.ylim[0] - ys),  # TL
             root.query_xy(self.xlim[1] + xs, self.ylim[0] - ys),  # TR
@@ -464,13 +464,13 @@ def interp_leaf(
 
     # BASIS POINTS ###################################
     # xb is the flat basis points
-    xb, yb = np.concatenate([l.data for l in interp_leaves]).T
-    zb = z[np.concatenate([l.index for l in interp_leaves])]
+    xb, yb = np.concatenate([el.data for el in interp_leaves]).T
+    zb = z[np.concatenate([el.index for el in interp_leaves])]
 
     # NEIGHBOURHOOD WEIGHTS ###########################
     # note that neighbourhood weights are calculated only with
     # the basis points and not with the interpolation
-    ii = [get_leaf_interp_points(l, xi, yi) for l in interp_leaves]
+    ii = [get_leaf_interp_points(el, xi, yi) for el in interp_leaves]
     ii = np.array(ii).any(axis=0)
     xn = xi[ii]
     yn = yi[ii]
@@ -694,10 +694,12 @@ def interp_obj(  # noqa: C901
         return model
 
     import multiprocessing as mp
+
     from functools import partial
     from time import perf_counter as timer
 
     import xarray as xr
+
     from sklearn import linear_model
 
     if (n_cpus is None) | (n_cpus == 0):

--- a/glidertools/optics.py
+++ b/glidertools/optics.py
@@ -453,7 +453,7 @@ def sunset_sunrise(time, lat, lon):
 
     # groupby days and find sunrise for unique days
     # groupby days and find sunrise/sunset for unique days
-    grp_avg = df.groupby(df.index).mean()
+    grp_avg = df.groupby(df.index).mean(numeric_only=False)
     date = grp_avg.index.to_pydatetime()
     date = grp_avg.index
 

--- a/glidertools/optics.py
+++ b/glidertools/optics.py
@@ -105,8 +105,9 @@ def par_dark_count(par, depth, time, depth_percentile=90):
     par_dark: numpy.ndarray or pandas.Series
         The par data corrected for the in situ dark value in units uE/m2/sec.
     """
-    from numpy import array, isnan, ma, nanmedian, nanpercentile
     import warnings
+
+    from numpy import array, isnan, ma, nanmedian, nanpercentile
 
     par_arr = array(par)
     depth = array(depth)
@@ -154,8 +155,9 @@ def backscatter_dark_count(bbp, depth, percentile=5):
     bbp: numpy.ndarray or pandas.Series
         The total backscatter data corrected for the in situ dark value.
     """
-    from numpy import array, isnan, nanpercentile
     import warnings
+
+    from numpy import array, isnan, nanpercentile
 
     bbp_dark = array(bbp)
     mask = (depth > 200) & (depth < 400)
@@ -198,8 +200,9 @@ def fluorescence_dark_count(flr, depth, percentile=5):
         The fluorescence data corrected for the in situ dark value.
 
     """
-    from numpy import array, isnan, nanpercentile
     import warnings
+
+    from numpy import array, isnan, nanpercentile
 
     mask = (depth > 300) & (depth < 400)
     flr_dark = array(flr)
@@ -280,6 +283,7 @@ def par_fill_surface(par, dives, depth, max_curve_depth=100):
 
     """
     import numpy as np
+
     from scipy.optimize import curve_fit
 
     def dive_par_fit(depth, par):
@@ -348,6 +352,7 @@ def photic_depth(par, dives, depth, return_mask=False, ref_percentage=1):
     """
     import numpy as np
     import pandas as pd
+
     from scipy.stats import linregress
 
     def dive_slope(par, depth):
@@ -431,12 +436,10 @@ def sunset_sunrise(time, lat, lon):
         An array of the sunset times.
 
     """
-
-    from pandas import DataFrame
-    import datetime
     import numpy as np
     import pandas as pd
 
+    from pandas import DataFrame
     from skyfield import api
 
     ts = api.load.timescale()
@@ -608,6 +611,7 @@ def quenching_correction(
 
     import numpy as np
     import pandas as pd
+
     from scipy.interpolate import Rbf
 
     from .cleaning import rolling_window
@@ -737,7 +741,7 @@ def quenching_correction(
     # apply the minimum gradient algorithm to each dive
     quench_mask = grp.apply(lambda df: grad_min(df.depth, df.flr_dif))
     # fill the quench_layer subscripted to the photic layer
-    quenching_layer[photic_layer] = np.concatenate([l for l in quench_mask])
+    quenching_layer[photic_layer] = np.concatenate([el for el in quench_mask])
 
     # ################################### #
     #  DO THE QUENCHING CORRECTION MAGIC  #

--- a/glidertools/physics.py
+++ b/glidertools/physics.py
@@ -58,6 +58,7 @@ def mixed_layer_depth(
         number of unique dives.
     """
     import numpy as np
+
     from pandas import DataFrame
 
     def mld_profile(dens_or_temp, depth, thresh, ref_depth, mask=False):
@@ -94,7 +95,7 @@ def mixed_layer_depth(
     )
 
     if return_as_mask:
-        return np.concatenate([l for l in mld])
+        return np.concatenate([el for el in mld])
     else:
         return mld
 

--- a/glidertools/plot.py
+++ b/glidertools/plot.py
@@ -368,7 +368,7 @@ class plot_functions(object):
 
         ax.set_ylim(ax.get_ylim()[::-1])
         ax.set_ylabel("Depth (m)")
-        ax.set_xlabel("$\Delta$ Depth (m)")  # noqa: W605
+        ax.set_xlabel(r"$\Delta$ Depth (m)")  # noqa: W605
         ax.legend(loc=0)
 
         if add_colorbar:
@@ -436,6 +436,7 @@ class plot_functions(object):
             raise ImportError("You need to install plotly for `section3D` to work")
         import numpy as np
         import plotly.graph_objs as go
+
         from matplotlib import cm
         from pandas import Series
 
@@ -523,6 +524,7 @@ class plot_functions(object):
         savefig_kwargs : key-value pairs passed to ``Figure.savefig``
         """
         import matplotlib.backends.backend_pdf
+
         from matplotlib import pyplot as plt
 
         pdf = matplotlib.backends.backend_pdf.PdfPages(pdf_name)

--- a/glidertools/processing.py
+++ b/glidertools/processing.py
@@ -153,6 +153,7 @@ def calc_oxygen(
     """
 
     import seawater as sw
+
     from numpy import abs, array, c_, isnan, median, ones
     from pandas import Series
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,9 +63,10 @@ classifiers =
     Intended Audience :: Science/Research,
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 ## Add your email here
 author_email = "lukegre@gmail.com"
@@ -88,7 +89,7 @@ install_requires =
 
 setup_requires=
     setuptools_scm
-python_requires = >=3.6
+python_requires = >=3.8
 ################ Up until here
 
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ line_length=88
 
 [tool:pytest]
 testpaths=tests/
-adopts= --cov --cov-fail-under=20
+addopts= --cov --cov-fail-under=20
 
 [doc8]
 # https://pypi.org/project/doc8/

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,4 +1,4 @@
-from glidertools.calibration import (
+from glidertools.calibration import (  # noqa
     bottle_matchup,
     model_figs,
     model_metrics,

--- a/tests/test_flo_functions.py
+++ b/tests/test_flo_functions.py
@@ -1,4 +1,4 @@
-from glidertools.flo_functions import (
+from glidertools.flo_functions import (  # noqa
     flo_bback_total,
     flo_beta,
     flo_cdom,

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,4 +1,4 @@
-from glidertools.mapping import (
+from glidertools.mapping import (  # noqa
     get_optimal_bins,
     grid_data,
     grid_flat_dataarray,

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -74,7 +74,6 @@ def test_backscatter_dark_count_negative(percentile):
 
 def test_backscatter_dark_count_warning():
     from glidertools.optics import backscatter_dark_count
-    import warnings
 
     # create some synthetic data
     percentile = 50
@@ -132,8 +131,9 @@ def test_flr_dark_count_warning():
 
 @pytest.mark.parametrize("percentile", [90])
 def test_par_dark_count(percentile):
-    from glidertools.optics import par_dark_count
     from pandas import date_range
+
+    from glidertools.optics import par_dark_count
 
     # create some synthetic data
     par = np.array([34, 23.0, 0.89, 0.89])
@@ -148,9 +148,9 @@ def test_par_dark_count(percentile):
 
 
 def test_par_dark_count_warning():
-    from glidertools.optics import par_dark_count
     from pandas import date_range
-    import warnings
+
+    from glidertools.optics import par_dark_count
 
     # create some synthetic data
     percentile = 90

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -30,7 +30,7 @@ ds_dict = seaglider_basestation_netCDFs(
 
 merged = ds_dict["merged"]
 if "time" in merged:
-    merged = merged.drop(["time", "time_dt64"])
+    merged = merged.drop_vars(["time", "time_dt64"])
 dat = merged.rename(
     {
         "salinity": "salt_raw",

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,4 +1,4 @@
-import pytest
+import warnings
 
 import glidertools.plot as gt_plt
 
@@ -16,15 +16,15 @@ dat = ds_dict["sg_data_point"]
 
 def test_no_warns():
     """Check gt_plt() raises no warnings in pcolormesh."""
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings() as record:
         gt_plt(dat.dives, dat.ctd_pressure, dat.salinity)
 
     # print warnings that were captured
-    if len(record) > 0:
+    if record:
         print("Warnings were raised: " + ", ".join([str(w) for w in record]))
 
-    # Check the warning messages for statements we do not want to see
-    fail_message = (
-        "shading='flat' when X and Y have the same dimensions as C is deprecated"
-    )
-    assert not any([fail_message in str(r) for r in record])
+        # Check the warning messages for statements we do not want to see
+        fail_message = (
+            "shading='flat' when X and Y have the same dimensions as C is deprecated"
+        )
+        assert not any([fail_message in str(r) for r in record])

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,4 +1,4 @@
-from glidertools.processing import (
+from glidertools.processing import (  # noqa
     calc_backscatter,
     calc_fluorescence,
     calc_oxygen,


### PR DESCRIPTION
 ```
On branch test-framework-maintanance-and-pre-deprecation-fixes
 Changes to be committed:
	modified:   .pre-commit-config.yaml
	modified:   docs/authors.md
	modified:   docs/conf.py
	modified:   glidertools/cleaning.py
	modified:   glidertools/load/slocum.py
	modified:   glidertools/mapping.py
	modified:   glidertools/optics.py
	modified:   glidertools/physics.py
	modified:   glidertools/plot.py
	modified:   glidertools/processing.py
	modified:   setup.cfg
	modified:   tests/test_optics.py
	modified:   tests/test_physics.py
	modified:   tests/test_plot.py

 Untracked files:
	de421.bsp
	glidertools/_version.py
```
**This contribution is not adding any new feature, but repairs and updates the development framework. I intended to write another contribution following the 'Contribution Guide', when I noticed the framework needs a bit of maintenance first before everything works again**

In the pre-commit-config.yaml, the versions of pre-commit-hooks, flake8, mirrors-isort, seed-isort and black are updated to the most recent ones. This is basic maintanance, before the old versions are getting deprecated. 
Also in `pre-comit-config.yaml`, the flake8 configuration is repaired which was broken before (double select keyword and syntax errors) The now working flake8 enforced some syntax changes before commiting, in the files `./glidertools/cleaning.py, ./glidertools/mapping.py and ./glidertools/optics.py` 
In the `/docs/conf.py`, some "u" in front of strings were removed. This was python2 notation to make strings unicode. In python3, which is already used in glidertools, all strings are in unicode by default. 
In the `./setup.cfg`  a misspelled keyword (addopts) for pytest is repaired, re-enabling the automatic testing, which was broken in a refactoring of the `setup.cfg` before. 
Some test code that was throwing deprecation warnings was refactored, e.g. `/tests/test_physics.py` and `/tests/test_plot.py` (see: [https://github.com/scipy/scipy/issues/15186](https://github.com/scipy/scipy/issues/15186)), also see (also see pytest-dev/pytest#9386) and #126 for more information. Moreover, some unused imports where removed.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #126 (this was not the main goal, but I think #126 was addressed coincidentally anyway ;)
 - [No] Tests added (but repaired existing ones)
 - [~] Passes `pre-commit run --all-files` (* see comments below)
 - [No] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [None] New functions/methods are listed in `api.rst`
 
(*) the pre-commit run --all-files now works with flake8 again and throws some warnings (see below). However, I do not want this pull request to become too big, so I believe this warnings should be addressed in a subsequent pull request for easier review. 

```
glidertools/load/seaglider.py:330:9: E722 do not use bare 'except'
glidertools/helpers.py:41:13: E722 do not use bare 'except'
tests/test_processing.py:1:1: F401 'glidertools.processing.calc_backscatter' imported but unused
tests/test_processing.py:1:1: F401 'glidertools.processing.calc_fluorescence' imported but unused
tests/test_processing.py:1:1: F401 'glidertools.processing.calc_oxygen' imported but unused
tests/test_processing.py:1:1: F401 'glidertools.processing.calc_par' imported but unused
tests/test_processing.py:1:1: F401 'glidertools.processing.calc_physics' imported but unused
tests/test_flo_functions.py:1:1: F401 'glidertools.flo_functions.flo_bback_total' imported but unused
tests/test_flo_functions.py:1:1: F401 'glidertools.flo_functions.flo_beta' imported but unused
tests/test_flo_functions.py:1:1: F401 'glidertools.flo_functions.flo_cdom' imported but unused
tests/test_flo_functions.py:1:1: F401 'glidertools.flo_functions.flo_chla' imported but unused
tests/test_flo_functions.py:1:1: F401 'glidertools.flo_functions.flo_density_seawater' imported but unused
tests/test_flo_functions.py:1:1: F401 'glidertools.flo_functions.flo_isotherm_compress' imported but unused
tests/test_flo_functions.py:1:1: F401 'glidertools.flo_functions.flo_refractive_index' imported but unused
tests/test_flo_functions.py:1:1: F401 'glidertools.flo_functions.flo_scale_and_offset' imported but unused
tests/test_flo_functions.py:1:1: F401 'glidertools.flo_functions.flo_scat_seawater' imported but unused
tests/test_flo_functions.py:1:1: F401 'glidertools.flo_functions.flo_zhang_scatter_coeffs' imported but unused
tests/test_mapping.py:1:1: F401 'glidertools.mapping.get_optimal_bins' imported but unused
tests/test_mapping.py:1:1: F401 'glidertools.mapping.grid_data' imported but unused
tests/test_mapping.py:1:1: F401 'glidertools.mapping.grid_flat_dataarray' imported but unused
tests/test_mapping.py:1:1: F401 'glidertools.mapping.interp_leaf' imported but unused
tests/test_mapping.py:1:1: F401 'glidertools.mapping.interp_obj' imported but unused
tests/test_mapping.py:1:1: F401 'glidertools.mapping.variogram' imported but unused
tests/test_calibration.py:1:1: F401 'glidertools.calibration.bottle_matchup' imported but unused
tests/test_calibration.py:1:1: F401 'glidertools.calibration.model_figs' imported but unused
tests/test_calibration.py:1:1: F401 'glidertools.calibration.model_metrics' imported but unused
tests/test_calibration.py:1:1: F401 'glidertools.calibration.robust_linear_fit' imported but unused
```
