### PR TITLE
fix zenodo doi badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ glidertools
         :target: https://www.gnu.org/licenses/gpl-3.0
 .. image:: https://img.shields.io/badge/Journal-10.3389%2Ffmars.2019.00738-blue
         :target: https://doi.org/10.3389/fmars.2019.00738
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3360280.svg
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4075238.svg
         :target: https://doi.org/10.5281/zenodo.4075238
 .. image:: https://codecov.io/gh/GliderToolsCommunity/GliderTools/branch/master/graph/badge.svg?token=FPUJ29TMSH
         :target: https://codecov.io/gh/GliderToolsCommunity/GliderTools

--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,8 @@ glidertools
         :target: https://www.gnu.org/licenses/gpl-3.0
 .. image:: https://img.shields.io/badge/Journal-10.3389%2Ffmars.2019.00738-blue
         :target: https://doi.org/10.3389/fmars.2019.00738
-.. image:: https://zenodo.org/badge/256331120.svg
-        :target: https://zenodo.org/badge/latestdoi/256331120
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3360280.svg
+        :target: https://zenodo.org/badge/DOI/10.5281/zenodo.3360280.svg
 .. image:: https://codecov.io/gh/GliderToolsCommunity/GliderTools/branch/master/graph/badge.svg?token=FPUJ29TMSH
         :target: https://codecov.io/gh/GliderToolsCommunity/GliderTools
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ glidertools
 .. image:: https://img.shields.io/badge/Journal-10.3389%2Ffmars.2019.00738-blue
         :target: https://doi.org/10.3389/fmars.2019.00738
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3360280.svg
-        :target: https://zenodo.org/badge/DOI/10.5281/zenodo.3360280.svg
+        :target: https://zenodo.org/record/4075239
 .. image:: https://codecov.io/gh/GliderToolsCommunity/GliderTools/branch/master/graph/badge.svg?token=FPUJ29TMSH
         :target: https://codecov.io/gh/GliderToolsCommunity/GliderTools
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ glidertools
 .. image:: https://img.shields.io/badge/Journal-10.3389%2Ffmars.2019.00738-blue
         :target: https://doi.org/10.3389/fmars.2019.00738
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3360280.svg
-        :target: https://zenodo.org/record/4075239
+        :target: https://doi.org/10.5281/zenodo.4075238
 .. image:: https://codecov.io/gh/GliderToolsCommunity/GliderTools/branch/master/graph/badge.svg?token=FPUJ29TMSH
         :target: https://codecov.io/gh/GliderToolsCommunity/GliderTools
 


### PR DESCRIPTION


@soerenthomsen this links to the original upload on zenodo https://zenodo.org/record/3360280

I'm using the doi to link to it to avoid ambiguity.

There are several other GliderTools uploads though, including this more recent version by Julius https://zenodo.org/record/4815417 

Which should we point to? I can't find any record of the old badge ID on zenodo. It doesn't correspond to any kind of doi
