### PR TITLE
docs: update index.rst: Python 3.6+ -> 3.8+

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@
 Glider Tools: profile data processing
 =====================================
 
-Glider tools is a Python 3.6+ package designed to process data from the first level of processing to a science ready dataset.
+Glider tools is a Python 3.8+ package designed to process data from the first level of processing to a science ready dataset.
 The package is designed to easily import data to a standard column format:
 ``numpy.ndarray``, ``pandas.DataFrame`` or ``xarray.DataArray`` (we recommend
 the latter which has full support for metadata).


### PR DESCRIPTION
For now I just updated the python version from 3.6+ to 3.8+

However I suggest we agree on how to align both descriptions of 
- the repo [readme.rst](https://github.com/GliderToolsCommunity/GliderTools#readme) and 
- the docs [index.rst](https://github.com/GliderToolsCommunity/GliderTools/blob/master/docs/index.rst) header

 - addresses parts of #159 
