### PR TITLE
delete unused imports from python2->python3 transition

### DIFF
--- a/glidertools/__init__.py
+++ b/glidertools/__init__.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import as _ai
-from __future__ import print_function as _pf
-from __future__ import unicode_literals as _ul
-
 import warnings as _warnings
 
 from pkg_resources import DistributionNotFound, get_distribution

--- a/glidertools/calibration.py
+++ b/glidertools/calibration.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import as _ai
-from __future__ import print_function as _pf
-from __future__ import unicode_literals as _ul
-
 from inspect import currentframe as getframe
 
 import numpy as _np

--- a/glidertools/cleaning.py
+++ b/glidertools/cleaning.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import as _ai
-from __future__ import print_function as _pf
-from __future__ import unicode_literals as _ul
-
 from inspect import currentframe as getframe
 
 from .helpers import transfer_nc_attrs

--- a/glidertools/flo_functions.py
+++ b/glidertools/flo_functions.py
@@ -36,10 +36,6 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-from __future__ import absolute_import as _ai
-from __future__ import print_function as _pf
-from __future__ import unicode_literals as _ul
-
 import numexpr as ne
 import numpy as np
 

--- a/glidertools/load/__init__.py
+++ b/glidertools/load/__init__.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import as _ai
-from __future__ import print_function as _pf
-from __future__ import unicode_literals as _ul
-
 from .ego import load_mission_nc as ego_mission_netCDF
 from .seaglider import load_multiple_vars as seaglider_basestation_netCDFs
 from .seaglider import show_variables as seaglider_show_variables

--- a/glidertools/load/seaglider.py
+++ b/glidertools/load/seaglider.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import as _ai
-from __future__ import print_function as _pf
-from __future__ import unicode_literals as _ul
-
 import numpy as np
 
 from netCDF4 import Dataset

--- a/glidertools/load/slocum.py
+++ b/glidertools/load/slocum.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import as _ai
-from __future__ import print_function as _pf
-from __future__ import unicode_literals as _ul
 
 
 def slocum_geomar_matfile(filename, verbose=True):

--- a/glidertools/optics.py
+++ b/glidertools/optics.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import as _ai
-from __future__ import print_function as _pf
-from __future__ import unicode_literals as _ul
-
 from inspect import currentframe as getframe
 
 from .helpers import transfer_nc_attrs

--- a/glidertools/physics.py
+++ b/glidertools/physics.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import as _ai
-from __future__ import print_function as _pf
-from __future__ import unicode_literals as _ul
-
 import warnings
 
 from inspect import currentframe as getframe

--- a/glidertools/plot.py
+++ b/glidertools/plot.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import as _ai
-from __future__ import print_function as _pf
-from __future__ import unicode_literals as _ul
-
 import numpy as np
 
 

--- a/glidertools/processing.py
+++ b/glidertools/processing.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import as _ai
-from __future__ import print_function as _pf
-from __future__ import unicode_literals as _ul
-
 from inspect import currentframe as getframe
 
 from .helpers import printv, transfer_nc_attrs

--- a/glidertools/utils.py
+++ b/glidertools/utils.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import as _ai
-from __future__ import print_function as _pf
-from __future__ import unicode_literals as _ul
-
 from inspect import currentframe as getframe
 
 from .helpers import transfer_nc_attrs


### PR DESCRIPTION

Hi, this pull request removes some clutter that had been useful in the transition from python2 to python3. The functions provided by the removed imports such as modern style print function and unicode strings are now a standard feature of all python versions supported by GliderTools. 