### PR TITLE
add concatenation of two or more datasets

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,8 +15,9 @@ Loading Data
    load.seaglider_show_variables
    load.ego_mission_netCDF
    load.slocum_geomar_matfile
-   load.voto_seaexplorer_nc
-   load.voto_seaexplorer_dataset
+   load.voto_seaexplorer.voto_seaexplorer_nc
+   load.voto_seaexplorer.voto_seaexplorer_dataset
+   load.voto_seaexplorer.concat_datasets
 
 
 High level processing

--- a/glidertools/load/voto_seaexplorer.py
+++ b/glidertools/load/voto_seaexplorer.py
@@ -59,3 +59,28 @@ def add_dive_column(ds):
         np.where(ds.profile_direction == 1, ds.profile_num, ds.profile_num + 0.5),
     )
     return ds
+
+
+def concat_datasets(datasets):
+    """
+    Concatenates multiple datasets along the time dimensions, profile_num
+    and dives variable(s) are adapted so that they start counting from one
+    for the first dataset and monotonically increase.
+
+    Parameters
+    ----------
+    datasets : list of xarray.Datasets
+
+    Returns
+    -------
+    xarray.Dataset
+        concatenated Dataset containing all the data from the list of datasets
+    """
+    for index in range(1, len(datasets)):
+        datasets[index]["profile_num"] += (
+            datasets[index - 1].copy()["profile_num"].max()
+        )
+    ds = xr.concat(datasets, dim="time")
+    ds = add_dive_column(ds)
+
+    return ds

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,9 +1,17 @@
-from glidertools.load.voto_seaexplorer import voto_seaexplorer_nc
+from glidertools.load.voto_seaexplorer import concat_datasets, voto_seaexplorer_nc
 
 
 filename = "./tests/data/voto_nrt.nc"
-ds = voto_seaexplorer_nc(filename)
+
+# import two times to test concat
+ds1 = voto_seaexplorer_nc(filename)
+ds2 = voto_seaexplorer_nc(filename)
 
 
 def test_dives_column_addition():
-    assert len(ds.dives) > 1
+    assert len(ds1.dives) > 1
+
+
+def test_concat_datasets():
+    ds_concat = concat_datasets([ds1, ds2])
+    assert 2 * len(ds1.time) == len(ds_concat.time)


### PR DESCRIPTION
 - [x] Tests added
 - [x] Passes `pre-commit run --all-files`
 - [x] New functions/methods are listed in `api.rst`

Hi, this PR adds the possibility to stack multiple datasets along the time dimension. While doing so, the "dives" and "profile_num" variables are automatically adapted, so that they do not repeat and can still be used for grouping, plotting etc. 
This is only working for the VOTO datasets yet, that's why I put it into the voto_seaexplorer module. I could think of a way to adapt it to different formats later if it proves useful. 
