### PR TITLE
Api and documentation changes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,9 +15,9 @@ Loading Data
    load.seaglider_show_variables
    load.ego_mission_netCDF
    load.slocum_geomar_matfile
-   load.voto_seaexplorer.voto_seaexplorer_nc
-   load.voto_seaexplorer.voto_seaexplorer_dataset
-   load.voto_seaexplorer.concat_datasets
+   load.voto_seaexplorer_nc
+   load.voto_seaexplorer_dataset
+   load.voto_concat_datasets
 
 
 High level processing

--- a/docs/loading.md
+++ b/docs/loading.md
@@ -45,7 +45,7 @@ gt.load.seaglider_show_variables(filenames)
 
 Glidertools supports loading Seaexplorer files. This is implemented and tested with `VOTO https://observations.voiceoftheocean.org`_ datasets in mind currently, but we are happy about feedback/pullrequests how it works for other SeaExplorer datasets. VOTO data can either be downloaded from the website using a browser or, more comfortable, from an `ERDAP server https://erddap.observations.voiceoftheocean.org/erddap/index.html`_ . See the `demo notebook <https://github.com/voto-ocean-knowledge/download_glider_data>`_ to get started with downloads over the API.
 
-After download of a .nc file or xarray-Dataset, it can be read into Glidertools by calling `gt.load.voto_seaexplorer_nc` or `gt.load.voto_seaexplorer_dataset` respectively. Resulting datasets can be merged by calling `gt.load.voto_concat_datasets`. The import of the data into GliderTools is hereby finished, remaining steps on this wiki-page are optional. 
+After download of a .nc file or xarray-Dataset, it can be read into Glidertools by calling `gt.load.voto_seaexplorer_nc` or `gt.load.voto_seaexplorer_dataset` respectively. Resulting datasets can be merged by calling `gt.load.voto_concat_datasets`. The import of the data into GliderTools is hereby finished, remaining steps on this wiki-page are optional.
 
 ## Load variables
 

--- a/docs/loading.md
+++ b/docs/loading.md
@@ -41,7 +41,11 @@ gt.load.seaglider_show_variables(filenames)
 
     <table will be displayed here>
 
+## Working with VOTO Seaexplorer files or xarray-datasets
 
+Glidertools supports loading Seaexplorer files. This is implemented and tested with `VOTO https://observations.voiceoftheocean.org`_ datasets in mind currently, but we are happy about feedback/pullrequests how it works for other SeaExplorer datasets. VOTO data can either be downloaded from the website using a browser or, more comfortable, from an `ERDAP server https://erddap.observations.voiceoftheocean.org/erddap/index.html`_ . See the `demo notebook <https://github.com/voto-ocean-knowledge/download_glider_data>`_ to get started with downloads over the API.
+
+After download of a .nc file or xarray-Dataset, it can be read into Glidertools by calling `gt.load.voto_seaexplorer_nc` or `gt.load.voto_seaexplorer_dataset` respectively. Resulting datasets can be merged by calling `gt.load.voto_concat_datasets`. The import of the data into GliderTools is hereby finished, remaining steps on this wiki-page are optional. 
 
 ## Load variables
 

--- a/glidertools/load/__init__.py
+++ b/glidertools/load/__init__.py
@@ -4,4 +4,8 @@ from .ego import load_mission_nc as ego_mission_netCDF
 from .seaglider import load_multiple_vars as seaglider_basestation_netCDFs
 from .seaglider import show_variables as seaglider_show_variables
 from .slocum import slocum_geomar_matfile
-from .voto_seaexplorer import voto_seaexplorer_dataset, voto_seaexplorer_nc
+from .voto_seaexplorer import (
+    voto_concat_datasets,
+    voto_seaexplorer_dataset,
+    voto_seaexplorer_nc,
+)

--- a/glidertools/load/voto_seaexplorer.py
+++ b/glidertools/load/voto_seaexplorer.py
@@ -61,7 +61,7 @@ def add_dive_column(ds):
     return ds
 
 
-def concat_datasets(datasets):
+def voto_concat_datasets(datasets):
     """
     Concatenates multiple datasets along the time dimensions, profile_num
     and dives variable(s) are adapted so that they start counting from one

--- a/glidertools/utils.py
+++ b/glidertools/utils.py
@@ -46,7 +46,7 @@ def time_average_per_dive(dives, time):
 
 def group_by_profiles(ds, variables=None):
     """
-    Group profiles by dives column, i.e. each group member is one dive. The
+    Group profiles by dives column. Each group member is one dive. The
     returned profiles can be evaluated statistically, e.g. by
     pandas.DataFrame.mean or other aggregating methods. To filter out one
     specific profile, use xarray.Dataset.where instead.
@@ -76,8 +76,8 @@ def mask_above_depth(ds, depths):
     """
     Masks all data above depths.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     df : xarray.Dataframe or pandas.Dataframe
     mask_depths : float (for constant depth masking) or pandas.Series as
         returned e.g. by the mixed_layer_depth function
@@ -89,8 +89,8 @@ def mask_below_depth(ds, depths):
     """
     Masks all data below depths.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     df : xarray.Dataframe or pandas.Dataframe
     mask_depths : float (for constant depth masking) or pandas.Series as
         returned e.g. by the mixed_layer_depth function
@@ -100,12 +100,13 @@ def mask_below_depth(ds, depths):
 
 def mask_profile_depth(df, mask_depth, above):
     """
-    masks either above or below mask_depth. If type(mask_depth)=np.nan,
+    Masks either above or below mask_depth. If type(mask_depth)=np.nan,
     the whole profile will be masked. Warning: This function is for a SINGLE
     profile only, for masking a complete Glider Dataset please look for
     utils.mask_above_depth and/or utils.mask_below_depth.
-    Parameters:
-    -----------
+
+    Parameters
+    ----------
     df : xarray.Dataframe or pandas.Dataframe
     mask_depths : float (for constant depth masking) or pandas.Series as
         returned e.g. by the mixed_layer_depth function

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,4 +1,4 @@
-from glidertools.load.voto_seaexplorer import concat_datasets, voto_seaexplorer_nc
+from glidertools.load import voto_concat_datasets, voto_seaexplorer_nc
 
 
 filename = "./tests/data/voto_nrt.nc"
@@ -12,6 +12,6 @@ def test_dives_column_addition():
     assert len(ds1.dives) > 1
 
 
-def test_concat_datasets():
-    ds_concat = concat_datasets([ds1, ds2])
+def test_voto_concat_datasets():
+    ds_concat = voto_concat_datasets([ds1, ds2])
     assert 2 * len(ds1.time) == len(ds_concat.time)


### PR DESCRIPTION
Api for `voto.load_seaexplorer`  cleaned. Loading is now `gt.load.voto_seaexplorer_dataset`. instead of previously`gt.load.voto_seaexplorer.voto_seaexplorer_dataset`. Also, some basic documentation about loading Seaglider Datasets into GliderTools is added. 
I also changed the docstrings of my newly defined functions, I hope this helps making them appear in the api-reference. (https://glidertools.readthedocs.io/en/latest/api.html)