### PR TITLE
re-run notebook with bundled dataset

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,0 +1,20 @@
+name: glidertools_notebooks
+channels:
+  - conda-forge
+dependencies:
+  - numexpr
+  - netCDF4
+  - pandas
+  - xarray >=2022.10.0
+  - numpy
+  - scikit-learn
+  - scipy
+  - tqdm
+  - matplotlib
+  - gsw
+  - skyfield
+  - jupyterlab
+  - cmocean
+  - pip
+  - pip:
+    - glidertools @ git+https://github.com/GliderToolsCommunity/GliderTools.git@master

--- a/notebooks/Demo_GT.ipynb
+++ b/notebooks/Demo_GT.ipynb
@@ -40,7 +40,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Import `GliderTools`"
+    "# Import `GliderTools`\n",
+    "\n",
+    "**N.B** to run this notebook, use the environment in the repo https://github.com/GliderToolsCommunity/GliderTools .binder/environment.yml"
    ]
   },
   {


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
 - [x] Passes `pre-commit run --all-files`

This PR aims to make the demo notebook from three years ago work again. The datafiles uploaded to the repo do not match those used in the orinigal run of the notebook. This may be the cause of some functions failing.

Once we have the whole notebook running, we can refactor it so that more advanced/variable specific functionality is in separate notebooks.


