### PR TITLE
Replace deprecated pkg_resources functions 

### DIFF
--- a/glidertools/__init__.py
+++ b/glidertools/__init__.py
@@ -19,9 +19,5 @@ from .plot import plot_functions as plot
 from .processing import *
 
 
-# from importlib.metadata import version, PackageNotFoundError
-# from pkg_resources import DistributionNotFound, get_distribution
-
-
 __version__ = package_version()
 _warnings.filterwarnings("ignore", category=RuntimeWarning)

--- a/glidertools/__init__.py
+++ b/glidertools/__init__.py
@@ -2,8 +2,6 @@
 
 import warnings as _warnings
 
-from pkg_resources import DistributionNotFound, get_distribution
-
 from . import (  # NOQA
     calibration,
     cleaning,
@@ -14,16 +12,16 @@ from . import (  # NOQA
     physics,
     utils,
 )
+from .helpers import package_version
 from .mapping import grid_data, interp_obj
 from .plot import logo as make_logo
 from .plot import plot_functions as plot
 from .processing import *
 
 
-try:
-    __version__ = get_distribution("glidertools").version
-except DistributionNotFound:
-    __version__ = "version_undefined"
-del get_distribution, DistributionNotFound
+# from importlib.metadata import version, PackageNotFoundError
+# from pkg_resources import DistributionNotFound, get_distribution
 
+
+__version__ = package_version()
 _warnings.filterwarnings("ignore", category=RuntimeWarning)

--- a/glidertools/helpers.py
+++ b/glidertools/helpers.py
@@ -1,12 +1,17 @@
 import inspect
 
-from pkg_resources import DistributionNotFound, get_distribution
 
+def package_version():
+    # package version will only be returned if package is installed through e.g. pip or conda,
+    # development code is unaware of its own version (and there is not such a thing in dev anyway).
+    # Advantage: We don't have to keep track of versioning manually
+    from importlib.metadata import PackageNotFoundError, version
 
-try:
-    version = get_distribution("glidertools").version
-except DistributionNotFound:
-    version = "version_undefined"
+    try:
+        version = version("glidertools")
+    except PackageNotFoundError:
+        version = "version_undefined"
+    return version
 
 
 class GliderToolsWarning(UserWarning):
@@ -79,7 +84,7 @@ def transfer_nc_attrs(frame, input_xds, output_arr, output_name, **attrs):
         attributes = input_xds.attrs.copy()
         history = "" if "history" not in attributes else attributes["history"]
         history += "[{}] (v{}) {};\n".format(
-            time_now(), version, rebuild_func_call(frame)
+            time_now(), package_version(), rebuild_func_call(frame)
         )
         attributes.update({"history": history})
         attributes.update(attrs)


### PR DESCRIPTION
This is some small changes of how GliderTools is handeling it's own version string. I refactored it because previously used `pkg_resources` is deprecated now. Also, I was able to remove some code duplication. Note that you will always get "version_undefined" as version string in a development environment. This is on purpose, the version string is based on the release number included when making a release, the last release can be installed the usual way over pip/conda.