### PR TITLE
fix-transfer-nc-attrs

### DIFF
--- a/glidertools/helpers.py
+++ b/glidertools/helpers.py
@@ -91,7 +91,7 @@ def transfer_nc_attrs(frame, input_xds, output_arr, output_name, **attrs):
 
         keys = list(attributes.keys())
         for key in keys:
-            if attributes[key] == "":
+            if str(attributes[key]) == "":
                 attributes.pop(key)
 
         xds = xr.DataArray(


### PR DESCRIPTION
fixes #192
(I deliberately convert to string and check for empty, to keep potentially useful attributes such as 0, 0.0, False, np.nan...)