### PR TITLE
Adjust glidertools description

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,10 +42,11 @@ ignore =
 
 [metadata]
 name = glidertools
-description = ("A toolkit for processing Seaglider base station NetCDF files: "
-        "despiking, smoothing, outlier detection, backscatter, fluorescence "
-        "quenching, calibration, gridding, interpolation. Documentation "
-        "at https://glidertools.readthedocs.io")
+description = ("A toolkit for Glider data: "
+    "processing of basestation files, despiking, smoothing, outlier detection, "
+	"backscatter, fluorescence quenching, calibration, gridding, interpolation, "
+	"profile-grouping, MLD. "
+    "Documentation at https://glidertools.readthedocs.io")
 author = Luke Gregor
 url = https://github.com/GliderToolsCommunity/GliderTools
 long_description = file: README.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,8 +44,8 @@ ignore =
 name = glidertools
 description = ("A toolkit for Glider data: "
     "processing of basestation files, despiking, smoothing, outlier detection, "
-	"backscatter, fluorescence quenching, calibration, gridding, interpolation, "
-	"profile-grouping, MLD. "
+    "backscatter, fluorescence quenching, calibration, gridding, interpolation, "
+    "profile-grouping, MLD. "
     "Documentation at https://glidertools.readthedocs.io")
 author = Luke Gregor
 url = https://github.com/GliderToolsCommunity/GliderTools


### PR DESCRIPTION
Currently, the headline description (e.g. for pypi.org) is "A toolkit for processing Seaglider base station NetCDF files".
Glidertools became more than that. Most parts are written glider-agnostic and I find it very useful for SeaExplorer data also. 