### PR TITLE
avoid extrapolation artefacts

### DIFF
--- a/glidertools/mapping.py
+++ b/glidertools/mapping.py
@@ -974,7 +974,9 @@ def grid_data(
     gridded = gridded.reindex(labels.astype(float))
 
     if interp_lim > 0:
-        gridded = gridded.interpolate(limit=interp_lim).bfill(limit=interp_lim)
+        gridded = gridded.interpolate(limit=interp_lim, limit_area="inside").bfill(
+            limit=interp_lim
+        )
 
     if not return_xarray:
         return gridded


### PR DESCRIPTION
This bugfix avoids extrapolation in the gridding process of the standard plotting function, e.g.:
`gt.plot(ds.profile_num, ds.depth, ds.temperature)`
**before:**
![Screenshot from 2024-04-11 14-32-55](https://github.com/GliderToolsCommunity/GliderTools/assets/37417617/666e7bc8-decb-4974-b166-7360a1863bfe)
**after bugfix:**
![Screenshot from 2024-04-11 14-32-32](https://github.com/GliderToolsCommunity/GliderTools/assets/37417617/84d281ef-f25c-4d4b-8119-e39656330ee5)

