### PR TITLE
correct typo in api creation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -118,8 +118,8 @@ General Utilities
    :toctree: ./_generated/
 
    utils.time_average_per_dive
-   utils.mask_above_depths
-   utils.mask_below_depths
+   utils.mask_above_depth
+   utils.mask_below_depth
    utils.mask_profile_depth
    utils.merge_dimensions
    utils.calc_glider_vert_velocity


### PR DESCRIPTION
Correct typo, which prevented automatic api documentation for some functions. 
